### PR TITLE
Refine Compose setup and async Wi-Fi operations

### DIFF
--- a/app/src/main/java/com/tbse/wnsw/MainActivity.kt
+++ b/app/src/main/java/com/tbse/wnsw/MainActivity.kt
@@ -10,17 +10,22 @@ import android.net.wifi.ScanResult
 import android.net.wifi.WifiManager
 import android.net.wifi.WifiManager.SCAN_RESULTS_AVAILABLE_ACTION
 import android.net.wifi.WifiNetworkSuggestion
+import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.tbse.tbse.wifi.database.APDao
 import com.tbse.tbse.wifi.database.AccessPoint
 import com.tbse.wifi.support.ModelMapper
@@ -30,7 +35,12 @@ import com.tbse.wnsw.ui.aplist.APProMainScreen
 import com.tbse.wnsw.ui.need_permissions.NeedPermissionsPage
 import com.tbse.wnsw.ui.theme.NewWNSWTheme
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.catch
 import java.time.LocalTime
 import javax.inject.Inject
 
@@ -43,7 +53,7 @@ val requiredPermissions = setOf(
 )
 
 @AndroidEntryPoint
-class MainActivity : AppCompatActivity(),
+class MainActivity : ComponentActivity(),
     ActivityCompat.OnRequestPermissionsResultCallback {
 
     @Inject
@@ -57,68 +67,22 @@ class MainActivity : AppCompatActivity(),
 
     private val apViewModel by viewModels<APListViewModel>()
 
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<String>,
-        grantResults: IntArray,
-    ) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == PERMISSION_REQUEST_LOCATION) {
-            // Request for camera permission.
-            if (grantResults.size == 1 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                // Permission has been granted. Start Activity.
-                init()
-            } else {
-                // Permission request was denied.
-                showNeedsPermissionsPage()
-            }
-        }
-    }
+    private val permissionState = MutableStateFlow(false)
 
-    override fun onResume() {
-        super.onResume()
+    private var scanResultsJob: Job? = null
 
-        if (hasPermissions()) {
-            registerScanResultsReceiver()
-            init()
-        } else {
-            requestPermissions()
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val permissionsGranted = hasPermissions()
+        updatePermissionState(permissionsGranted)
+        if (!permissionsGranted) {
+            requestRequiredPermissions()
         }
 
-    }
-
-    private fun registerScanResultsReceiver() {
-        applicationContext
-            .registerReceiverAsFlow(SCAN_RESULTS_AVAILABLE_ACTION)
-            .onEach { intent ->
-                wifiManager.scanResults
-                    .map {
-                        val ap = mapScanResultToAccessPoint(it)
-                        apDao.insertAP(ap)
-                    }
-                StringBuilder().apply {
-                    append("Action: ${intent.action}\n")
-                    append("URI: ${intent.toUri(Intent.URI_INTENT_SCHEME)}\n")
-                    toString().also { log ->
-                        Log.d(TAG, log)
-                        Toast.makeText(applicationContext, log, Toast.LENGTH_LONG).show()
-                    }
-                }
-            }
-    }
-
-    private fun showNeedsPermissionsPage() {
         setContent {
-            NewWNSWTheme {
-                NeedPermissionsPage {
-                    requestPermissions()
-                }
-            }
-        }
-    }
+            val hasPermissions by permissionState.collectAsState()
 
-    private fun init() {
-        setContent {
             val lastLoad = remember {
                 mutableStateOf(LocalTime.now())
             }
@@ -128,44 +92,100 @@ class MainActivity : AppCompatActivity(),
 
             NewWNSWTheme {
                 Surface(color = MaterialTheme.colors.background) {
-                    APProMainScreen(
-                        apViewModel = apViewModel,
-                        setLastLoad = setLastLoad,
-                        addNetworkSuggestions = ::addNetworkSuggestions,
-                        removeNetworkSuggestions = ::removeNetworkSuggestions
-                    )
+                    if (hasPermissions) {
+                        APProMainScreen(
+                            apViewModel = apViewModel,
+                            setLastLoad = setLastLoad,
+                            addNetworkSuggestions = ::addNetworkSuggestions,
+                            removeNetworkSuggestions = ::removeNetworkSuggestions
+                        )
+                    } else {
+                        NeedPermissionsPage {
+                            requestRequiredPermissions()
+                        }
+                    }
                 }
             }
         }
     }
 
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<String>,
+        grantResults: IntArray,
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == PERMISSION_REQUEST_LOCATION) {
+            val granted = grantResults.isNotEmpty() &&
+                grantResults.all { it == PackageManager.PERMISSION_GRANTED }
+            updatePermissionState(granted)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        updatePermissionState(hasPermissions())
+    }
+
+    override fun onDestroy() {
+        scanResultsJob?.cancel()
+        super.onDestroy()
+    }
+
+    private fun updatePermissionState(granted: Boolean) {
+        permissionState.value = granted
+        if (granted) {
+            startWifiScanCollection()
+        } else {
+            stopWifiScanCollection()
+        }
+    }
+
+    private fun startWifiScanCollection() {
+        if (scanResultsJob?.isActive == true) {
+            return
+        }
+        scanResultsJob = lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(androidx.lifecycle.Lifecycle.State.STARTED) {
+                persistLatestScanResults()
+                applicationContext
+                    .registerReceiverAsFlow(SCAN_RESULTS_AVAILABLE_ACTION)
+                    .catch { throwable ->
+                        Log.e(TAG, "Failed to receive Wi-Fi scan results", throwable)
+                    }
+                    .collect { intent ->
+                        persistLatestScanResults()
+                        logScanIntent(intent)
+                    }
+            }
+        }
+    }
+
+    private fun stopWifiScanCollection() {
+        scanResultsJob?.cancel()
+        scanResultsJob = null
+    }
+
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-        init()
+        updatePermissionState(hasPermissions())
     }
 
     companion object {
         fun getWifiScanIntent(context: Context): Intent {
-            val i = Intent(context, MainActivity::class.java)
-            i.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-            i.putExtra("wifi_scan", "1")
-            return i
+            return Intent(context, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                putExtra("wifi_scan", "1")
+            }
         }
     }
 
     private fun hasPermissions(): Boolean {
-        return if (
-            requiredPermissions.all {
-                ContextCompat.checkSelfPermission(
-                    applicationContext,
-                    it
-                ) == PackageManager.PERMISSION_GRANTED
-            }
-        ) {
-            true
-        } else {
-            requestPermissions()
-            false
+        return requiredPermissions.all {
+            ContextCompat.checkSelfPermission(
+                applicationContext,
+                it
+            ) == PackageManager.PERMISSION_GRANTED
         }
     }
 
@@ -174,7 +194,7 @@ class MainActivity : AppCompatActivity(),
      * If an additional rationale should be displayed, the user has to launch the request from
      * a SnackBar that includes additional information.
      */
-    private fun requestPermissions() {
+    private fun requestRequiredPermissions() {
         ActivityCompat.requestPermissions(
             this,
             requiredPermissions.toTypedArray(),
@@ -183,11 +203,67 @@ class MainActivity : AppCompatActivity(),
     }
 
     private fun addNetworkSuggestions(list: List<WifiNetworkSuggestion>) {
-        wifiManager.addNetworkSuggestions(list)
+        lifecycleScope.launch(Dispatchers.IO) {
+            val status = wifiManager.addNetworkSuggestions(list)
+            handleSuggestionStatus(status, true)
+        }
     }
 
     private fun removeNetworkSuggestions(list: List<WifiNetworkSuggestion>) {
-        wifiManager.removeNetworkSuggestions(list)
+        lifecycleScope.launch(Dispatchers.IO) {
+            val status = wifiManager.removeNetworkSuggestions(list)
+            handleSuggestionStatus(status, false)
+        }
     }
 
+    private suspend fun persistLatestScanResults() {
+        try {
+            withContext(Dispatchers.IO) {
+                wifiManager.scanResults.forEach { scanResult: ScanResult ->
+                    val ap = mapScanResultToAccessPoint(scanResult)
+                    apDao.insertAP(ap)
+                }
+            }
+        } catch (securityException: SecurityException) {
+            Log.w(TAG, "Missing permission for Wi-Fi scan results", securityException)
+        }
+    }
+
+    private suspend fun logScanIntent(intent: Intent) {
+        withContext(Dispatchers.Main) {
+            StringBuilder().apply {
+                append("Action: ${intent.action}\n")
+                append("URI: ${intent.toUri(Intent.URI_INTENT_SCHEME)}\n")
+                toString().also { log ->
+                    Log.d(TAG, log)
+                    Toast.makeText(applicationContext, log, Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+    }
+
+    private suspend fun handleSuggestionStatus(status: Int, isAddOperation: Boolean) {
+        withContext(Dispatchers.Main) {
+            if (status != WifiManager.STATUS_NETWORK_SUGGESTIONS_SUCCESS) {
+                val message = when (status) {
+                    WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_ADD_EXCEEDS_MAX_PER_APP ->
+                        "Too many network suggestions requested"
+                    WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_ADD_DUPLICATE ->
+                        "Duplicate network suggestion provided"
+                    WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_ADD_INVALID ->
+                        "Invalid network suggestion"
+                    WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_ADD_NOT_ALLOWED ->
+                        "Adding network suggestions is not allowed"
+                    WifiManager.STATUS_NETWORK_SUGGESTIONS_ERROR_REMOVE_INVALID ->
+                        "Unable to remove network suggestion"
+                    else -> "Suggestion operation failed with status $status"
+                }
+                Log.w(TAG, message)
+                Toast.makeText(applicationContext, message, Toast.LENGTH_LONG).show()
+            } else {
+                val operation = if (isAddOperation) "added" else "removed"
+                Log.d(TAG, "Network suggestions successfully $operation")
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/tbse/wnsw/ui/aplist/APListViewModel.kt
+++ b/app/src/main/java/com/tbse/wnsw/ui/aplist/APListViewModel.kt
@@ -8,10 +8,12 @@ import androidx.lifecycle.viewModelScope
 import com.tbse.wnsw.TAG
 import com.tbse.wnsw.models.AccessPointUI
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 sealed interface APListUiState {
@@ -48,7 +50,9 @@ class APListViewModel @Inject constructor(
 ) : AndroidViewModel(application) {
 
     init {
-        wifiManager.startScan()
+        viewModelScope.launch(Dispatchers.IO) {
+            wifiManager.startScan()
+        }
     }
 
     private val viewModelState = MutableStateFlow(


### PR DESCRIPTION
## Summary
- migrate MainActivity to a ComponentActivity that sets Compose content once and switches between the main UI and the permissions screen from state
- collect Wi-Fi scan broadcasts with lifecycle-aware coroutines that persist results off the main thread and surface permission issues gracefully
- execute Wi-Fi network suggestion changes on a background dispatcher and report the outcome to the user, while starting scans asynchronously in the view model

## Testing
- ./gradlew lint *(fails: Android SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8917a5d40832cb5fb7c05a86b4f44