### PR TITLE
Add GitHub Actions workflow for Gradle builds

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -1,0 +1,28 @@
+name: Gradle Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs Gradle builds on pushes and pull requests targeting `main`
- configure Java 11 with caching and execute the Gradle wrapper

## Testing
- not run (workflow configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68d0b0e3e3e4832cad80839a4b5dac04