### PR TITLE
Add Compose previews for all UI components

### DIFF
--- a/app/src/main/java/com/tbse/wnsw/ui/aplist/APListLazyColumn.kt
+++ b/app/src/main/java/com/tbse/wnsw/ui/aplist/APListLazyColumn.kt
@@ -2,8 +2,12 @@ package com.tbse.wnsw.ui.aplist
 
 import android.net.wifi.WifiNetworkSuggestion
 import android.view.MotionEvent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
@@ -78,4 +82,21 @@ fun APListLazyColumnPreview() {
         {},
         {}
     )
+}
+
+@Preview
+@Composable
+private fun GetBGColorPreview() {
+    Row {
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .background(getBGColor(isClicked = false))
+        )
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .background(getBGColor(isClicked = true))
+        )
+    }
 }

--- a/app/src/main/java/com/tbse/wnsw/ui/aplist/APProMainScreen.kt
+++ b/app/src/main/java/com/tbse/wnsw/ui/aplist/APProMainScreen.kt
@@ -1,7 +1,6 @@
 package com.tbse.wnsw.ui.aplist
 
 import android.net.wifi.WifiNetworkSuggestion
-import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.Scaffold
@@ -9,8 +8,10 @@ import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import com.tbse.wnsw.TAG
-import com.tbse.wnsw.models.AccessPointUI
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.tbse.wnsw.ui.aplist.preview.APListUiStatePreviewProvider
+import com.tbse.wnsw.ui.theme.NewWNSWTheme
 
 /**
  * Created by toddsmith on 5/15/21.
@@ -26,6 +27,21 @@ fun APProMainScreen(
 
     val uiState = apViewModel.uiState.collectAsState().value
 
+    APProMainScreenContent(
+        uiState = uiState,
+        setLastLoad = setLastLoad,
+        addNetworkSuggestions = addNetworkSuggestions,
+        removeNetworkSuggestions = removeNetworkSuggestions
+    )
+}
+
+@Composable
+private fun APProMainScreenContent(
+    uiState: APListUiState,
+    setLastLoad: () -> Unit,
+    addNetworkSuggestions: (List<WifiNetworkSuggestion>) -> Unit,
+    removeNetworkSuggestions: (List<WifiNetworkSuggestion>) -> Unit,
+) {
     Scaffold(
         topBar = {
             ApListAppBar()
@@ -56,4 +72,20 @@ fun APProMainScreen(
             )
         }
     )
+}
+
+@Preview
+@Composable
+private fun APProMainScreenPreview(
+    @PreviewParameter(APListUiStatePreviewProvider::class)
+    uiState: APListUiState,
+) {
+    NewWNSWTheme {
+        APProMainScreenContent(
+            uiState = uiState,
+            setLastLoad = {},
+            addNetworkSuggestions = {},
+            removeNetworkSuggestions = {}
+        )
+    }
 }

--- a/app/src/main/java/com/tbse/wnsw/ui/aplist/TopAppBar.kt
+++ b/app/src/main/java/com/tbse/wnsw/ui/aplist/TopAppBar.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.tbse.wnsw.R
+import com.tbse.wnsw.ui.theme.NewWNSWTheme
 
 /**
  * Created by toddsmith on 12/13/21.
@@ -18,6 +19,14 @@ import com.tbse.wnsw.R
 @Composable
 fun ApListAppBar() {
     DefaultAppBar()
+}
+
+@Preview
+@Composable
+private fun PreviewApListAppBar() {
+    NewWNSWTheme {
+        ApListAppBar()
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/tbse/wnsw/ui/aplist/preview/APListUiStatePreviewProvider.kt
+++ b/app/src/main/java/com/tbse/wnsw/ui/aplist/preview/APListUiStatePreviewProvider.kt
@@ -1,0 +1,13 @@
+package com.tbse.wnsw.ui.aplist.preview
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.tbse.wnsw.ui.aplist.APListUiState
+
+class APListUiStatePreviewProvider : PreviewParameterProvider<APListUiState> {
+    override val values: Sequence<APListUiState> = sequenceOf(
+        APListUiState.NoAPs,
+        APListUiState.HasListOfAPs(
+            aps = AccessPointPreviewProviderMany().values.toList()
+        )
+    )
+}

--- a/app/src/main/java/com/tbse/wnsw/ui/theme/Theme.kt
+++ b/app/src/main/java/com/tbse/wnsw/ui/theme/Theme.kt
@@ -2,9 +2,12 @@ package com.tbse.wnsw.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 
 private val DarkColorPalette = darkColors(
         primary = Purple200,
@@ -41,4 +44,14 @@ fun NewWNSWTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composabl
             shapes = Shapes,
             content = content
     )
+}
+
+@Preview
+@Composable
+private fun NewWNSWThemePreview() {
+    NewWNSWTheme {
+        Surface {
+            Text(text = "Theme Preview")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a reusable preview provider for AP list UI states
- introduce previews for the theme, app bar, and AP list background helper
- refactor the main screen to support previews of the full AP list experience

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6901ae590832cb26e7485ae21b107